### PR TITLE
Update for the new file tree implementation

### DIFF
--- a/src/baincomplexinstallerdialog.cpp
+++ b/src/baincomplexinstallerdialog.cpp
@@ -96,9 +96,6 @@ void BainComplexInstallerDialog::updateTree(std::shared_ptr<IFileTree> &tree)
         newTree->merge(entry->astree());
       }
     }
-    else {
-      newTree->insert(entry);
-    }
   }
 
   tree = newTree;

--- a/src/baincomplexinstallerdialog.cpp
+++ b/src/baincomplexinstallerdialog.cpp
@@ -75,10 +75,7 @@ QString BainComplexInstallerDialog::getName() const
 
 void BainComplexInstallerDialog::updateTree(std::shared_ptr<IFileTree> &tree)
 {
-  // Note (Holt59): The version with DirectoryTree was a bit convoluted
-  // as the only things that need to be done is removed directory not selected,
-  // and these directory can only be at the root of the tree.
-
+  // Retrieve the list of selected names:
   std::set<QString, FileNameComparator> selectedNames;
   for (int i = 0; i < ui->optionsList->count(); ++i) {
     QListWidgetItem* item = ui->optionsList->item(i);
@@ -87,14 +84,11 @@ void BainComplexInstallerDialog::updateTree(std::shared_ptr<IFileTree> &tree)
     }
   }
 
-  // Start from an empty tree and insert everything (easier since
-  // we cannot modify the tree while iterating):
+  // Create a new empty tree and merge all the selected folder in it:
   auto newTree = tree->createOrphanTree();
   for (auto& entry : *tree) {
-    if (entry->isDir()) {
-      if (selectedNames.count(entry->name()) > 0) {
+    if (entry->isDir() && selectedNames.count(entry->name()) > 0) {
         newTree->merge(entry->astree());
-      }
     }
   }
 

--- a/src/baincomplexinstallerdialog.cpp
+++ b/src/baincomplexinstallerdialog.cpp
@@ -21,13 +21,15 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "textviewer.h"
 #include "ui_baincomplexinstallerdialog.h"
 
-#include <QDir>
+#include <QCompleter>
 
 
 using namespace MOBase;
 
 
-BainComplexInstallerDialog::BainComplexInstallerDialog(DirectoryTree *tree, const GuessedValue<QString> &modName, const QString &packageTXT, QWidget *parent)
+BainComplexInstallerDialog::BainComplexInstallerDialog(
+  std::shared_ptr<MOBase::IFileTree> tree, const GuessedValue<QString> &modName, 
+  const QString &packageTXT, QWidget *parent)
   : TutorableDialog("BainInstaller", parent), ui(new Ui::BainComplexInstallerDialog), m_Manual(false),
     m_PackageTXT(packageTXT)
 {
@@ -39,22 +41,24 @@ BainComplexInstallerDialog::BainComplexInstallerDialog(DirectoryTree *tree, cons
 
   ui->nameCombo->setCurrentIndex(ui->nameCombo->findText(modName));
 
-  for (DirectoryTree::const_node_iterator iter = tree->nodesBegin(); iter != tree->nodesEnd(); ++iter) {
-    const FileNameString &dirName = (*iter)->getData().name;
-    if (dirName == "fomod" || dirName.startsWith("--")) {
+  for (auto &entry: *tree) {
+    const QString &dirName = entry->name().toLower();
+    
+    
+    if (!entry->isDir() || dirName == "fomod" || dirName.startsWith("--")) {
       continue;
     }
 
     QListWidgetItem *item = new QListWidgetItem(ui->optionsList);
-    item->setText(dirName.toQString());
+    item->setText(dirName);
     item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
     item->setCheckState(item->text().mid(0, 2) == "00" ? Qt::Checked : Qt::Unchecked);
-    item->setData(Qt::UserRole, qVariantFromValue((void*)(*iter)));
+
     ui->optionsList->addItem(item);
   }
 
   ui->packageBtn->setEnabled(!packageTXT.isEmpty());
-  ui->nameCombo->setAutoCompletionCaseSensitivity(Qt::CaseSensitive);
+  ui->nameCombo->completer()->setCaseSensitivity(Qt::CaseSensitive);
 }
 
 
@@ -69,36 +73,35 @@ QString BainComplexInstallerDialog::getName() const
   return ui->nameCombo->currentText();
 }
 
-
-void BainComplexInstallerDialog::moveTreeUp(DirectoryTree *target, DirectoryTree::Node *child)
+void BainComplexInstallerDialog::updateTree(std::shared_ptr<IFileTree> &tree)
 {
-  for (DirectoryTree::const_node_iterator iter = child->nodesBegin();
-       iter != child->nodesEnd();) {
-    target->addNode(*iter, true);
-    iter = child->detach(iter);
-  }
+  // Note (Holt59): The version with DirectoryTree was a bit convoluted
+  // as the only things that need to be done is removed directory not selected,
+  // and these directory can only be at the root of the tree.
 
-  for (DirectoryTree::const_leaf_reverse_iterator iter = child->leafsRBegin();
-       iter != child->leafsREnd(); ++iter) {
-    target->addLeaf(*iter);
-  }
-}
-
-
-DirectoryTree *BainComplexInstallerDialog::updateTree(DirectoryTree *tree)
-{
-  DirectoryTree *newTree = new DirectoryTree;
-  // create a new tree adding all "wanted" options and leaving the unwanted ones in the old tree
-  for (DirectoryTree::const_node_iterator iter = tree->nodesBegin();
-       iter != tree->nodesEnd();) {
-    QList<QListWidgetItem*> items = ui->optionsList->findItems((*iter)->getData().name.toQString(), Qt::MatchFixedString);
-    if ((items.count() == 1) && (items.at(0)->checkState() == Qt::Checked)) {
-      moveTreeUp(newTree, *iter);
+  std::set<QString, FileNameComparator> selectedNames;
+  for (int i = 0; i < ui->optionsList->count(); ++i) {
+    QListWidgetItem* item = ui->optionsList->item(i);
+    if (item->checkState() == Qt::Checked) {
+      selectedNames.insert(item->text());
     }
-    iter = tree->erase(iter);
   }
 
-  return newTree;
+  // Start from an empty tree and insert everything (easier since
+  // we cannot modify the tree while iterating):
+  auto newTree = tree->createOrphanTree();
+  for (auto& entry : *tree) {
+    if (entry->isDir()) {
+      if (selectedNames.count(entry->name()) > 0) {
+        newTree->merge(entry->astree());
+      }
+    }
+    else {
+      newTree->insert(entry);
+    }
+  }
+
+  tree = newTree;
 }
 
 

--- a/src/baincomplexinstallerdialog.h
+++ b/src/baincomplexinstallerdialog.h
@@ -20,11 +20,10 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef BAINCOMPLEXINSTALLERDIALOG_H
 #define BAINCOMPLEXINSTALLERDIALOG_H
 
-
-#include "mytree.h"
-#include "tutorabledialog.h"
-#include <directorytree.h>
 #include <guessedvalue.h>
+#include "ifiletree.h"
+
+#include "tutorabledialog.h"
 
 
 namespace Ui {
@@ -48,7 +47,7 @@ public:
   * @param packageTXT path to the extracted package.txt file or an empty string if there is none
   * @param parent parent widget
   **/
- explicit BainComplexInstallerDialog(MOBase::DirectoryTree *tree, const MOBase::GuessedValue<QString> &modName,
+ explicit BainComplexInstallerDialog(std::shared_ptr<MOBase::IFileTree> tree, const MOBase::GuessedValue<QString> &modName,
                                      const QString &packageTXT, QWidget *parent);
   ~BainComplexInstallerDialog();
 
@@ -63,14 +62,11 @@ public:
   QString getName() const;
 
   /**
-   * @brief retrieve the updated archive tree from the dialog. The caller is responsible to delete the returned tree.
+   * @brief Remove from the given tree the option not selected by the user.
    * 
-   * @note This call is destructive on the input tree!
-   *
-   * @param tree input tree. (TODO isn't this the same as the tree passed in the constructor?)
-   * @return DataTree* a new tree with only the selected options and directories arranged correctly. The caller takes custody of this pointer!
+   * @param tree The input tree.
    **/
-  MOBase::DirectoryTree *updateTree(MOBase::DirectoryTree *tree);
+  void updateTree(std::shared_ptr<MOBase::IFileTree> &tree);
 
 private slots:
 
@@ -81,10 +77,6 @@ private slots:
   void on_cancelBtn_clicked();
 
   void on_packageBtn_clicked();
-
-private:
-
-  void moveTreeUp(MOBase::DirectoryTree *target, MOBase::DirectoryTree::Node *child);
 
 private:
 

--- a/src/baincomplexinstallerdialog.ui
+++ b/src/baincomplexinstallerdialog.ui
@@ -56,22 +56,6 @@ If there is a component called &quot;00 Core&quot; it is usually required. Optio
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QPushButton" name="packageBtn">
-       <property name="toolTip">
-        <string>The package.txt is often part of BAIN packages and contains details about the options available.</string>
-       </property>
-       <property name="whatsThis">
-        <string>The package.txt is often part of BAIN packages and contains details about the options available.</string>
-       </property>
-       <property name="text">
-        <string notr="true">Package.txt</string>
-       </property>
-       <property name="autoDefault">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="manualBtn">
        <property name="toolTip">
         <string>Opens a Dialog that allows custom modifications.</string>
@@ -81,6 +65,22 @@ If there is a component called &quot;00 Core&quot; it is usually required. Optio
        </property>
        <property name="text">
         <string>Manual</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="packageBtn">
+       <property name="toolTip">
+        <string>The package.txt is often part of BAIN packages and contains details about the options available.</string>
+       </property>
+       <property name="whatsThis">
+        <string>The package.txt is often part of BAIN packages and contains details about the options available.</string>
+       </property>
+       <property name="text">
+        <string notr="true">Package.txt</string>
        </property>
        <property name="autoDefault">
         <bool>false</bool>

--- a/src/installerbain.h
+++ b/src/installerbain.h
@@ -47,13 +47,37 @@ public:
   virtual unsigned int priority() const;
   virtual bool isManualInstaller() const;
 
-  virtual bool isArchiveSupported(const MOBase::DirectoryTree &tree) const;
-  virtual EInstallResult install(MOBase::GuessedValue<QString> &modName, MOBase::DirectoryTree &tree,
+  virtual bool isArchiveSupported(std::shared_ptr<const MOBase::IFileTree> tree) const;
+  virtual EInstallResult install(MOBase::GuessedValue<QString> &modName, std::shared_ptr<MOBase::IFileTree> &tree,
                                  QString &version, int &modID);
 
 private:
 
-  bool isValidTopLayer(const MOBase::DirectoryTree::Node *node) const;
+  bool isValidTopLayer(const MOBase::IFileTree *tree) const;
+
+  /**
+   * @brief Test if the specified directory qualifies as a top-level directory. A top-level directory
+   * is one that contains data used by the game and goes directly below the "data" directory.
+   * The most common examples are "textures" and "meshes". On top of these, this function will 
+   * also accept directories that are not used by the game itself but by the BAIN installer ("ini tweaks" 
+   * and docs)
+   *
+   * @param dirName The directory name to test.
+   *
+   * @return true if the specified directory is a top-level directory
+   **/
+  static bool isTopLevelDirectoryBain(const QString& dirName);
+
+  /**
+   * Test if the specified file qualifies as a top-level file. A top-level file is one
+   * that will be used by the game if it's directly inside the "data" directory.
+   * These are ".esp", ".esm", ".esl" and ".bsa".
+   *
+   * @param suffix Extension of the file to test.
+
+   * @return bool
+   **/
+  static bool isTopLevelSuffix(const QString& suffix);
 
 private:
 


### PR DESCRIPTION
**Important:** This PR depends on https://github.com/ModOrganizer2/modorganizer-uibase/pull/48

Content of the PR:
- Modification of the installer for the new file tree implementation.
- Switch the "Package.txt" and "Manual" button to have the "Manual" button at a consistent position with the other installers (left-most button).