### PR TITLE
Better subpackages

### DIFF
--- a/src/baincomplexinstallerdialog.cpp
+++ b/src/baincomplexinstallerdialog.cpp
@@ -28,7 +28,7 @@ using namespace MOBase;
 
 
 BainComplexInstallerDialog::BainComplexInstallerDialog(
-  std::shared_ptr<MOBase::IFileTree> tree, const GuessedValue<QString> &modName, 
+  const std::vector<std::shared_ptr<const MOBase::FileTreeEntry>> &subpackages, const GuessedValue<QString> &modName,
   const QStringList& defaultOptions, const QString &packageTXT, QWidget *parent)
   : TutorableDialog("BainInstaller", parent), ui(new Ui::BainComplexInstallerDialog), m_Manual(false),
     m_PackageTXT(packageTXT)
@@ -41,19 +41,14 @@ BainComplexInstallerDialog::BainComplexInstallerDialog(
 
   ui->nameCombo->setCurrentIndex(ui->nameCombo->findText(modName));
 
-  for (auto &entry: *tree) {
-    const QString &dirName = entry->name().toLower();
-    
-    
-    if (!entry->isDir() || dirName == "fomod" || dirName.startsWith("--")) {
-      continue;
-    }
+  for (const auto& subpackage : subpackages) {
 
-    QListWidgetItem *item = new QListWidgetItem(ui->optionsList);
-    item->setText(dirName);
+    auto name = subpackage->name();
+
+    QListWidgetItem *item = new QListWidgetItem(name, ui->optionsList);
     item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
 
-    if (dirName.mid(0, 2) == "00" || defaultOptions.contains(dirName, Qt::CaseInsensitive)) {
+    if (name.mid(0, 2) == "00" || defaultOptions.contains(name, Qt::CaseInsensitive)) {
       item->setCheckState(Qt::Checked);
     }
     else {

--- a/src/baincomplexinstallerdialog.h
+++ b/src/baincomplexinstallerdialog.h
@@ -48,7 +48,7 @@ public:
   * @param packageTXT path to the extracted package.txt file or an empty string if there is none
   * @param parent parent widget
   **/
- explicit BainComplexInstallerDialog(std::shared_ptr<MOBase::IFileTree> tree,
+ explicit BainComplexInstallerDialog(const std::vector<std::shared_ptr<const MOBase::FileTreeEntry>> &subpackages,
                                      const MOBase::GuessedValue<QString> &modName,
                                      const QStringList &defaultOptions,
                                      const QString &packageTXT, QWidget *parent);

--- a/src/installerbain.h
+++ b/src/installerbain.h
@@ -54,6 +54,19 @@ public:
   virtual EInstallResult install(MOBase::GuessedValue<QString> &modName, std::shared_ptr<MOBase::IFileTree> &tree,
                                  QString &version, int &modID);
 
+protected:
+
+  /**
+   * @brief Retrieve the entries corresponding to subpackages in the given tree.
+   *
+   * @param tree The tree to check for subpackages.
+   * @param invalidFolders If not null, will contain the number of invalid folders.
+   *
+   * @return the list of entries corresponding to subpackages.
+   */
+  std::vector<std::shared_ptr<const MOBase::FileTreeEntry>> findSubpackages(
+    std::shared_ptr<const MOBase::IFileTree> tree, std::size_t *invalidFolders = nullptr) const;
+
 private:
 
   const MOBase::IOrganizer *m_MOInfo;


### PR DESCRIPTION
Two changes (related):

1. Consider more folders as "not invalid" when looking for sub-packages (`images`, `screenshots` and `docs`).
2. When showing the dialog, do not display the folder that are skipped during check. Previously, folder such as "omod conversion data" or "fomod" would not be taken into account when checking for the archive but would be displayed in the list of options.